### PR TITLE
Add link to documentation

### DIFF
--- a/src/components/HomePageHeader/index.tsx
+++ b/src/components/HomePageHeader/index.tsx
@@ -27,6 +27,13 @@ const HomeHead:FC = () => {
             >
               Get Started
             </a>
+            <br/>
+            <a
+              className="button button--lg button--primary fw-normal fs-20 btnMain"
+              href="https://answer.dev/docs"
+            >
+              Documenation
+            </a>
 
             {/* <a
               className={clsx('button button--lg button--secondary fw-normal fs-20', styles.white)}


### PR DESCRIPTION
Currently the only doc link is in the footer, easily missed by casual visitors.