### PR TITLE
docs: add missing image to zh-CN questions documentation

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/questions.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/questions.md
@@ -8,6 +8,10 @@ slug: /questions
 
 ![Question state diagram](/img/docs/questions-question-status.drawio.svg)
 
-## Apache Answer status
+## Question visibility
 
-![Apache Answer state diagram](/img/docs/questions-answer-status.drawio.svg)
+![Question visibility diagram](/img/docs/questions-question-visibility.drawio.svg)
+
+## Answer status
+
+![Answer state diagram](/img/docs/questions-answer-status.drawio.svg)


### PR DESCRIPTION
This PR adds the missing image in the zh-CN questions documentation page to keep it consistent with the English version.

English page:
https://answer.apache.org/docs/questions/

Chinese page:
https://answer.apache.org/zh-CN/docs/questions/

close #346 