### PR TITLE
chore: update latest release to 2.0.2

### DIFF
--- a/static/data/latest.json
+++ b/static/data/latest.json
@@ -1,7 +1,7 @@
 {
   "release": {
-    "date": "2026-05-29",
-    "version": "2.0.1",
-    "url": "https://github.com/apache/answer/releases/tag/v2.0.1"
+    "date": "2026-07-21",
+    "version": "2.0.2",
+    "url": "https://github.com/apache/answer/releases/tag/v2.0.2"
   }
 }


### PR DESCRIPTION
Update the latest release metadata to Apache Answer 2.0.2.