### PR TITLE
docs: note the CORS requirement for CDN-served assets

### DIFF
--- a/docs/getting-started/configfile.md
+++ b/docs/getting-started/configfile.md
@@ -38,3 +38,11 @@ ui:
   api_url: '/' # api url for  ajax requests
   base_url: ''  # the default deployment is in the root directory, you need to change this value when deploying in a subdirectory
 ```
+
+:::tip
+
+Starting with the release that includes the frontend migration to Vite ([apache/answer#1567](https://github.com/apache/answer/pull/1567)), the frontend loads as ES modules instead of classic scripts. Same-origin deployments, where Answer serves its own static assets, need no changes.
+
+If your deployment serves static assets from a separate CDN origin, for example through the `cdn-aliyun` or `cdn-s3` plugin, the CDN must send an `Access-Control-Allow-Origin` header matching your site's origin (scheme, host, and port, for example `https://example.com`). A module script is always fetched in CORS mode, so without that header the browser refuses to run it and the page loads with no JavaScript, even though the request for the file itself succeeds. See the CDN plugin's README for a concrete CORS rule for that provider.
+
+:::

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -60,8 +60,8 @@ When there are other unexpected cases such as upgrade exceptions, we provide a c
 
 :::caution
 
-Starting with the release that migrates the frontend build to Vite, the frontend loads as ES modules instead of classic scripts. Same-origin deployments, where Answer serves its own static assets, need no changes.
+Starting with the release that includes the frontend migration to Vite ([apache/answer#1567](https://github.com/apache/answer/pull/1567)), the frontend loads as ES modules instead of classic scripts. Same-origin deployments, where Answer serves its own static assets, need no changes.
 
-If your deployment serves static assets from a separate CDN origin, for example through the `cdn-aliyun` or `cdn-s3` plugin, the CDN must send an `Access-Control-Allow-Origin` header matching your site's origin. A module script is always fetched in CORS mode, so without that header the browser refuses to run it and the page loads with no JavaScript, even though the request for the file itself succeeds. See the CDN plugin's README for a concrete CORS rule for that provider.
+If your deployment serves static assets from a separate CDN origin, for example through the `cdn-aliyun` or `cdn-s3` plugin, the CDN must send an `Access-Control-Allow-Origin` header matching your site's origin (scheme, host, and port, for example `https://example.com`). A module script is always fetched in CORS mode, so without that header the browser refuses to run it and the page loads with no JavaScript, even though the request for the file itself succeeds. See the CDN plugin's README for a concrete CORS rule for that provider.
 
 :::

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -58,10 +58,4 @@ When there are other unexpected cases such as upgrade exceptions, we provide a c
 
 :::
 
-:::caution
-
-Starting with the release that includes the frontend migration to Vite ([apache/answer#1567](https://github.com/apache/answer/pull/1567)), the frontend loads as ES modules instead of classic scripts. Same-origin deployments, where Answer serves its own static assets, need no changes.
-
-If your deployment serves static assets from a separate CDN origin, for example through the `cdn-aliyun` or `cdn-s3` plugin, the CDN must send an `Access-Control-Allow-Origin` header matching your site's origin (scheme, host, and port, for example `https://example.com`). A module script is always fetched in CORS mode, so without that header the browser refuses to run it and the page loads with no JavaScript, even though the request for the file itself succeeds. See the CDN plugin's README for a concrete CORS rule for that provider.
-
-:::
+If you serve static assets from a separate CDN origin, ensure CORS is configured: see the [configuration file documentation](/docs/configfile) and the CDN plugin's README.

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -57,3 +57,11 @@ If you are using a binary installation of answer, the upgrade steps are as follo
 When there are other unexpected cases such as upgrade exceptions, we provide a command to manually force the upgrade of Apache Answer. `answer upgrade -f v1.1.0` Executing this command will force upgrade from the specified version, even if your Apache Answer is already up to date. If you encounter an upgrade exception, you can try to execute this command or pull the latest docker image again and execute this command inside the container.
 
 :::
+
+:::caution
+
+Starting with the release that migrates the frontend build to Vite, the frontend loads as ES modules instead of classic scripts. Same-origin deployments, where Answer serves its own static assets, need no changes.
+
+If your deployment serves static assets from a separate CDN origin, for example through the `cdn-aliyun` or `cdn-s3` plugin, the CDN must send an `Access-Control-Allow-Origin` header matching your site's origin. A module script is always fetched in CORS mode, so without that header the browser refuses to run it and the page loads with no JavaScript, even though the request for the file itself succeeds. See the CDN plugin's README for a concrete CORS rule for that provider.
+
+:::


### PR DESCRIPTION
Adds a caution block to the upgrade guide for deployments that serve static assets from a separate CDN origin: with the frontend moving to ES modules in apache/answer#1567, the CDN must send Access-Control-Allow-Origin for the site origin or pages load without JavaScript. Same-origin deployments are unaffected and the note says so explicitly. Requested by review on that PR; wording carries the crossorigin rationale documented there. Companion to apache/answer#1567, best merged with or after it.